### PR TITLE
Add keyed node support

### DIFF
--- a/Html.elm
+++ b/Html.elm
@@ -51,6 +51,12 @@ and CSS properties must be set using the JavaScript version of their name, so
 node : String -> [Attribute] -> [CssProperty] -> [Html] -> Html
 node = Native.Html.node
 
+{-| Same as node but associate a key string to this node allowing to accuratly track
+children in an array.
+-}
+keyedNode : String -> String -> [Attribute] -> [CssProperty] -> [Html] -> Html
+keyedNode = Native.Html.keyedNode
+
 {-| Create a DOM node, just like with the `node` function, but you can add event
 listeners. See the `Html.Events` library for more details.
 

--- a/Native/Html.js
+++ b/Native/Html.js
@@ -1494,10 +1494,10 @@ Elm.Native.Html.make = function(elm) {
     }
 
     function eventNode(name, attributes, properties, handlers, contents) {
-        return keyedEventNode(name, null, attributes, properties, List.Nil, contents);	
+        return keyedEventNode(name, null, attributes, properties, handlers, contents);	
     }
 
-    function keyedEventNode(name, key, attributes, properties, handlers, contents) {
+    function keyedEventNode(name, nodeKey, attributes, properties, handlers, contents) {
         var attrs = {};
         while (attributes.ctor !== '[]') {
             var attribute = attributes._0;
@@ -1516,7 +1516,7 @@ Elm.Native.Html.make = function(elm) {
             attrs[handler.eventName] = DataSetHook(handler.eventHandler);
             handlers = handlers._1;
         }
-        return new VNode(name, attrs, List.toArray(contents), key);
+        return new VNode(name, attrs, List.toArray(contents), nodeKey);
     }
 
     function pair(key,value) {
@@ -1759,6 +1759,7 @@ Elm.Native.Html.make = function(elm) {
     return Elm.Native.Html.values = {
         node: F4(node),
         keyedNode: F5(keyedNode),
+        keyedEventNode: F6(keyedEventNode),
         eventNode: F5(eventNode),
         text: text,
         on: F2(on),

--- a/Native/Html.js
+++ b/Native/Html.js
@@ -1487,10 +1487,17 @@ Elm.Native.Html.make = function(elm) {
     var eq = Elm.Native.Utils.make(elm).eq;
 
     function node(name, attributes, properties, contents) {
-        return eventNode(name, attributes, properties, List.Nil, contents);
+        return keyedEventNode(name, null, attributes, properties, List.Nil, contents);
+    }
+    function keyedNode(name, key, attributes, properties, contents) {
+        return keyedEventNode(name, key, attributes, properties, List.Nil, contents);
     }
 
     function eventNode(name, attributes, properties, handlers, contents) {
+        return keyedEventNode(name, null, attributes, properties, List.Nil, contents);	
+    }
+
+    function keyedEventNode(name, key, attributes, properties, handlers, contents) {
         var attrs = {};
         while (attributes.ctor !== '[]') {
             var attribute = attributes._0;
@@ -1509,7 +1516,7 @@ Elm.Native.Html.make = function(elm) {
             attrs[handler.eventName] = DataSetHook(handler.eventHandler);
             handlers = handlers._1;
         }
-        return new VNode(name, attrs, List.toArray(contents));
+        return new VNode(name, attrs, List.toArray(contents), key);
     }
 
     function pair(key,value) {
@@ -1751,6 +1758,7 @@ Elm.Native.Html.make = function(elm) {
 
     return Elm.Native.Html.values = {
         node: F4(node),
+        keyedNode: F5(keyedNode),
         eventNode: F5(eventNode),
         text: text,
         on: F2(on),

--- a/wrapper.js
+++ b/wrapper.js
@@ -26,10 +26,17 @@ Elm.Native.Html.make = function(elm) {
     var eq = Elm.Native.Utils.make(elm).eq;
 
     function node(name, attributes, properties, contents) {
-        return eventNode(name, attributes, properties, List.Nil, contents);
+        return keyedEventNode(name, null, attributes, properties, List.Nil, contents);
+    }
+    function keyedNode(name, key, attributes, properties, contents) {
+        return keyedEventNode(name, key, attributes, properties, List.Nil, contents);
     }
 
     function eventNode(name, attributes, properties, handlers, contents) {
+        return keyedEventNode(name, null, attributes, properties, List.Nil, contents);	
+    }
+
+    function keyedEventNode(name, key, attributes, properties, handlers, contents) {
         var attrs = {};
         while (attributes.ctor !== '[]') {
             var attribute = attributes._0;
@@ -48,7 +55,7 @@ Elm.Native.Html.make = function(elm) {
             attrs[handler.eventName] = DataSetHook(handler.eventHandler);
             handlers = handlers._1;
         }
-        return new VNode(name, attrs, List.toArray(contents));
+        return new VNode(name, attrs, List.toArray(contents), key);
     }
 
     function pair(key,value) {
@@ -290,6 +297,7 @@ Elm.Native.Html.make = function(elm) {
 
     return Elm.Native.Html.values = {
         node: F4(node),
+        keyedNode: F5(keyedNode),
         eventNode: F5(eventNode),
         text: text,
         on: F2(on),

--- a/wrapper.js
+++ b/wrapper.js
@@ -33,7 +33,7 @@ Elm.Native.Html.make = function(elm) {
     }
 
     function eventNode(name, attributes, properties, handlers, contents) {
-        return keyedEventNode(name, null, attributes, properties, List.Nil, contents);	
+        return keyedEventNode(name, null, attributes, properties, handlers, contents);	
     }
 
     function keyedEventNode(name, key, attributes, properties, handlers, contents) {
@@ -298,6 +298,7 @@ Elm.Native.Html.make = function(elm) {
     return Elm.Native.Html.values = {
         node: F4(node),
         keyedNode: F5(keyedNode),
+        keyedEventNode: F6(keyedEventNode),
         eventNode: F5(eventNode),
         text: text,
         on: F2(on),


### PR DESCRIPTION
Solve evancz/elm-html#2 in a very basic way (I have been using elm only for two hours when writing this).

It may be better to extract the key from the attribute list and avoid duplicating the node creation functions and the additional parameter.