### PR TITLE
Make "on" work with any event name

### DIFF
--- a/Native/Html.js
+++ b/Native/Html.js
@@ -1477,7 +1477,7 @@ Elm.Native.Html.make = function(elm) {
         return elm.Native.Html.values = Elm.Native.Html.values;
 
     // This manages event listeners. Somehow...
-    Delegator();
+    var delegator = Delegator();
 
     var RenderUtils = ElmRuntime.use(ElmRuntime.Render.Utils);
     var newElement = Elm.Graphics.Element.make(elm).newElement;
@@ -1514,6 +1514,7 @@ Elm.Native.Html.make = function(elm) {
 
     function on(name, coerce) {
         function createListener(handle, convert) {
+            delegator.listenTo(name);
             function eventHandler(event) {
                 var value = coerce(event);
                 if (value.ctor === 'Just') {


### PR DESCRIPTION
Hi. I've found myself wanting to use Html.on(..) with some less-common, possibly non-standard events. (In my case "search" and "touchstart".) At present since their names aren't listed in the javascript array commonEvents, the DOMDelegator is never asked to listen for them and they are ignored. This patch simply adds a call to DOMDelegator.listenTo(<event name>) in the createListener function itself - as listenTo is a no-op if called more than once this seems fairly harmless, but perhaps there's a better place for it?

Alternatively, if the intention is that on(..) should only be used with a fixed set of standard events, perhaps these should be documented on the Elm side? (Or on(..) changed to take an ADT rather than a string.)

[I should say so far I've only actually tested this on your master branch, not on the refresh.]
