### PR TITLE
Fix mousemove bug

### DIFF
--- a/Native/Html.js
+++ b/Native/Html.js
@@ -1476,8 +1476,7 @@ Elm.Native.Html.make = function(elm) {
     if ('values' in Elm.Native.Html)
         return elm.Native.Html.values = Elm.Native.Html.values;
 
-    // This manages event listeners. Somehow...
-    Delegator();
+    initDelegator();
 
     var RenderUtils = ElmRuntime.use(ElmRuntime.Render.Utils);
     var newElement = Elm.Graphics.Element.make(elm).newElement;
@@ -1485,6 +1484,12 @@ Elm.Native.Html.make = function(elm) {
     var List = Elm.Native.List.make(elm);
     var Maybe = Elm.Maybe.make(elm);
     var eq = Elm.Native.Utils.make(elm).eq;
+
+    function initDelegator(){
+      // This manages event listeners. Somehow...
+      var delegator = Delegator();
+      delegator.listenTo('mousemove');
+    }
 
     function node(name, attributes, properties, contents) {
         return eventNode(name, attributes, properties, List.Nil, contents);

--- a/wrapper.js
+++ b/wrapper.js
@@ -15,8 +15,7 @@ Elm.Native.Html.make = function(elm) {
     if ('values' in Elm.Native.Html)
         return elm.Native.Html.values = Elm.Native.Html.values;
 
-    // This manages event listeners. Somehow...
-    Delegator();
+    initDelegator();
 
     var RenderUtils = ElmRuntime.use(ElmRuntime.Render.Utils);
     var newElement = Elm.Graphics.Element.make(elm).newElement;
@@ -24,6 +23,12 @@ Elm.Native.Html.make = function(elm) {
     var List = Elm.Native.List.make(elm);
     var Maybe = Elm.Maybe.make(elm);
     var eq = Elm.Native.Utils.make(elm).eq;
+
+    function initDelegator(){
+      // This manages event listeners. Somehow...
+      var delegator = Delegator();
+      delegator.listenTo('mousemove');
+    }
 
     function node(name, attributes, properties, contents) {
         return eventNode(name, attributes, properties, List.Nil, contents);


### PR DESCRIPTION
onmousemove function does not attach mousemove event handler to html dom
element because mousemove event is not whitelisted in dom-delegator library.
See

https://github.com/Raynos/dom-delegator/blob/master/index.js#L10-L16

According to docs

https://github.com/Raynos/mercury/blob/master/docs/life-cycles.md#reacting-to-dom-events

we should call delegator.listenTo('mousemove') to fix this issue.