### PR TITLE
Added the SVG function.

### DIFF
--- a/Html.elm
+++ b/Html.elm
@@ -50,6 +50,19 @@ a list of child nodes.
 node : String -> [Attribute] -> [Html] -> Html
 node = Native.Html.node
 
+{-| Defines an embedded vectorial image.
+      svg "svg"
+        [ attr "height" "100"
+        , attr "width" "100"
+        ] 
+        [svg "circle"
+          [ attr "cx" "50"
+          , attr "cy" "50"
+          , attr "r" "25"] []]
+-}
+svg : String -> [Attribute] -> [Html] -> Html
+svg = Native.Html.svg
+
 {-| Just put plain text in the DOM. It will escape the string so that it appears
 exactly as you specify.
 

--- a/Html/Tags.elm
+++ b/Html/Tags.elm
@@ -18,7 +18,7 @@ topic of the section it introduces.
 @docs ol, ul, li, dl, dt, dd
 
 # Emdedded Content
-@docs img, iframe, canvas, svg, math
+@docs img, iframe, canvas, math
 
 # Inputs
 @docs form, input, textarea, button, select, option
@@ -422,10 +422,6 @@ map = node "map"
 area : [Attribute] -> [Html] -> Html
 area = node "area"
 --}
-
-{-| Defines an embedded vectorial image. -}
-svg : [Attribute] -> [Html] -> Html
-svg = node "svg"
 
 {-| Defines a mathematical formula. -}
 math : [Attribute] -> [Html] -> Html


### PR DESCRIPTION
I implemented the SVG function.
The current implementation of the SVG tag does not work because SVG attributes cannot be set directly, they have to be set by calling a setAttribute function.
More information can be found here:
https://github.com/Matt-Esch/virtual-dom/issues/55

The solution is to create a hook for each attribute, and call that attribute hook when the attribute is set.
Mercury implements this function, and I basically copied their implementation:
https://github.com/Raynos/virtual-hyperscript/blob/master/svg.js

There are many things unclear to me though.  So please take a look at the code before accepting it.
I think eventually SVG should have its own type because normal HTML nodes cannot be nested within SVG elements, and the current implementation does not check that.
