### PR TITLE
Fix colspan and rowspan attributes.

### DIFF
--- a/Html/Attributes.elm
+++ b/Html/Attributes.elm
@@ -151,7 +151,7 @@ instead.
 -}
 tabindex : Int -> Attribute
 tabindex n =
-    attr "tabindex" (show n)
+    attr "tabIndex" (show n)
 
 
 -- HEADER STUFF
@@ -432,7 +432,7 @@ list value =
 -}
 maxlength : Int -> Attribute
 maxlength n =
-    attr "maxlength" (show n)
+    attr "maxLength" (show n)
 
 {-| Defines which HTTP method to use when submitting a `form`. Can be GET
 (default) or POST.
@@ -473,7 +473,7 @@ pattern value =
 {-| Indicates whether an `input` or `textarea` can be edited. -}
 readonly : Bool -> Attribute
 readonly bool =
-    toggle "readonly" bool
+    toggle "readOnly" bool
 
 {-| Indicates whether this element is required to fill out or not.
 For `input`, `select`, and `textarea`.


### PR DESCRIPTION
This is super minor, but I noticed that the colspan and rowspan attributes had a typo, since the JavaScript attribute names differ from their HTML counterparts. This is related to #12. I didn't change any of the Elm function/alias names (avoid breaking change).

There are probably others like this but I haven't combed through all the attributes yet.
