### PR TITLE
Fix casing in readOnly attribute

### DIFF
--- a/src/Html/Attributes.elm
+++ b/src/Html/Attributes.elm
@@ -614,7 +614,7 @@ pattern value =
 {-| Indicates whether an `input` or `textarea` can be edited. -}
 readonly : Bool -> Attribute
 readonly bool =
-    boolProperty "readonly" bool
+    boolProperty "readOnly" bool
 
 {-| Indicates whether this element is required to fill out or not.
 For `input`, `select`, and `textarea`.


### PR DESCRIPTION
While the `readonly` attribute is all lower case in HTML, in JavaScript the property needs to be camel-cased. See [the MDN docs for `HTMLInputElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement) for more info.