### PR TITLE
Allow the string "any" with step

### DIFF
--- a/src/Html/Attributes.elm
+++ b/src/Html/Attributes.elm
@@ -669,10 +669,12 @@ min : String -> Attribute
 min value =
     stringProperty "min" value
 
-{-| Add a step size to an `input`. -}
-step : Int -> Attribute
+{-| Add a step size to an `input`. Use `step "any"` to allow any floating-point
+number to be used in the input.
+-}
+step : String -> Attribute
 step n =
-    stringProperty "step" (toString n)
+    stringProperty "step" n
 
 
 --------------------------


### PR DESCRIPTION
http://www.w3.org/TR/html-markup/input.number.html#input.number.attrs.step.float

```elm
step "any" -- allows any floating point number to be used in the input
           -- if this is not included the field validation produces an error
           -- when a floating point number is entered
           -- ("The two nearest values valid values are 0 and 1")
```