### PR TITLE
Preload attribute accepts strings

### DIFF
--- a/src/Html/Attributes.elm
+++ b/src/Html/Attributes.elm
@@ -398,9 +398,9 @@ loop bool =
     boolProperty "loop" bool
 
 {-| Control how much of an `audio` or `video` resource should be preloaded. -}
-preload : Bool -> Attribute
-preload bool =
-    boolProperty "preload" bool
+preload : String -> Attribute
+preload value =
+    stringProperty "preload" value
 
 {-| A URL indicating a poster frame to show until the user plays or seeks the
 `video`.


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video the values that `preload` accepts if it is given are
* `"none"`
* `"metadata"`
* `"auto"`
* `""` (the empty string)