### PR TITLE
Documentation: Fix example for Html.Attribute.attribute

### DIFF
--- a/src/Html/Attributes.elm
+++ b/src/Html/Attributes.elm
@@ -193,11 +193,9 @@ boolProperty name bool =
 {-| Create arbitrary HTML *attributes*. Maps onto JavaScript&rsquo;s
 `setAttribute` function under the hood.
 
-    import JavaScript.Encode (string)
-
     greeting : Html
     greeting =
-        div [ attribute "class" (string "greeting") ] [
+        div [ attribute "class" "greeting" ] [
           text "Hello!"
         ]
 


### PR DESCRIPTION
Html.Attribute.attribute takes a normal string as its second argument, but the example shows it with Json.Value.