### PR TITLE
bump virtual-dom dependency to 2.0.0

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -14,7 +14,7 @@
     ],
     "dependencies": {
         "elm-lang/core": "2.0.0 <= v < 3.0.0",
-        "evancz/virtual-dom": "1.0.0 <= v < 3.0.0"
+        "evancz/virtual-dom": "2.0.0 <= v < 3.0.0"
     },
     "elm-version": "0.15.0 <= v < 0.16.0"
 }


### PR DESCRIPTION
for onWithOptions.

Otherwise when I declare a dep on elm-html 4.0.0 I get this from `elm-package install`:

```
Error: Unable to get elm-package.json for evancz/virtual-dom 1.1.0
Missing field "elm-version", acceptable versions of the Elm Platform (e.g. "0.15.1 <= v < 0.16.0").
    Check out an example elm-package.json file here:
    <https://raw.githubusercontent.com/evancz/elm-html/master/elm-package.json>
```