### PR TITLE
Have onSubmit use preventDefault

### DIFF
--- a/src/Html/Events.elm
+++ b/src/Html/Events.elm
@@ -228,7 +228,14 @@ onFocus =
   messageOn "focus"
 
 
-{-|-}
+{-| Capture a [submit](https://developer.mozilla.org/en-US/docs/Web/Events/submit)
+event with [`preventDefault`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault)
+in order to prevent the form from changing the page’s location.
+-}
 onSubmit : Signal.Address a -> a -> Attribute
-onSubmit =
-  messageOn "submit"
+onSubmit addr msg =
+  onWithOptions "submit" onSubmitOptions value (\_ -> Signal.message addr msg)
+
+
+onSubmitOptions =
+  { defaultOptions | preventDefault <- True }


### PR DESCRIPTION
Given how the [`submit`](https://developer.mozilla.org/en-US/docs/Web/Events/submit) event works and how Elm works, there are almost no use cases for an `onSubmit` helper that does not set `preventDefault = True`.

This PR changes the `onSubmit` helper to set `preventDefault = True` and otherwise leaves it the same.

## Reasoning

0. The `submit` event is useful to capture because it is triggered whenever the user presses `Enter` while the focus is on any field inside a `<form>` element.
1. When the user submits a form, by default this causes current location changes to whatever URL the form's `action` attribute is set to.
2. If you add a submit handler to that form, the handler will synchronously run to completion before the form actually submits.
3. Once the handler has finished running, if `event.stopPropagation()` has been invoked, the page's location will not change. Otherwise, it will immediately be changed.
4. There is currently no way for an `elm-html` handler to conditionally set `stopPropagation`, which implies that the current `onSubmit` handler will always run synchronously to completion, followed by a form submission.
5. Any synchronous effects (e.g. view updates, sending to a port) such a handler could perform would be wiped out ASAP the location change, so they are almost never useful. The only one that comes to mind is disabling the Submit button in order to prevent double submissions due to impatient clicking.
6. Stopping propagation gives you time for things like: validating the form (possibly requiring async tasks, e.g. if AJAX "is this email/username available" validations are part of the validation process), submitting via AJAX instead of by raw form submission, [submitting a different form](https://groups.google.com/d/msg/elm-discuss/W3X_m1mE70w/02J3Jf4dCQAJ) now that you know validations have passed, etc.

tl;dr the only real-world use case for the current `onSubmit` handler seems to be disabling the Submit button to guard against multiple submissions, and all other use cases want `preventDefault` set.