### PR TITLE
Adding a function for virtual-dom's defaultValue property.

### DIFF
--- a/src/Html/Attributes.elm
+++ b/src/Html/Attributes.elm
@@ -1,7 +1,7 @@
 module Html.Attributes
     ( key, style
     , class, classList, id, title, hidden
-    , type', value, checked, placeholder, selected
+    , type', value, defaultValue, checked, placeholder, selected
     , accept, acceptCharset, action, autocomplete, autofocus, autosave
     , disabled, enctype, formaction, list, maxlength, minlength, method, multiple
     , name, novalidate, pattern, readonly, required, size, for, form
@@ -36,7 +36,7 @@ Attributes](#custom-attributes) section to learn how to create new helpers.
 @docs class, classList, id, title, hidden
 
 # Inputs
-@docs type', value, checked, placeholder, selected
+@docs type', value, defaultValue, checked, placeholder, selected
 
 ## Input Helpers
 @docs accept, acceptCharset, action, autocomplete, autofocus, autosave,
@@ -519,12 +519,19 @@ type' value =
   stringProperty "type" value
 
 
-{-| Defines a default value which will be displayed in a `button`, `option`,
+{-| Defines a value which will be displayed in a `button`, `option`,
 `input`, `li`, `meter`, `progress`, or `param`.
 -}
 value : String -> Attribute
 value value =
   stringProperty "value" value
+
+{-| Defines a default value which will be displayed the first time a `button`, `option`,
+`input`, `li`, `meter`, `progress`, or `param` is rendered.
+-}
+defaultValue : String -> Attribute
+defaultValue value =
+  stringProperty "defaultValue" value
 
 
 {-| Indicates whether an `input` of type checkbox is checked. -}


### PR DESCRIPTION
This is needed if you want to set an initial value for a form
element. (In contrast with the "value" property, which sets the value on
every re-render.)
