### PR TITLE
Corrected typo in autocomplete documentation

### DIFF
--- a/src/Html/Attributes.elm
+++ b/src/Html/Attributes.elm
@@ -571,7 +571,7 @@ action value =
   stringProperty "action" value
 
 
-{-| Indicates whether a `form` anor `input` can have their values automatically
+{-| Indicates whether a `form` or an `input` can have their values automatically
 completed by the browser.
 -}
 autocomplete : Bool -> Attribute


### PR DESCRIPTION
Corrected a basic typo in the documentation for autocomplete. "anor" should be "or an".