### PR TITLE
Html.Attributes.value docs should mention textarea

### DIFF
--- a/src/Html/Attributes.elm
+++ b/src/Html/Attributes.elm
@@ -520,7 +520,7 @@ type' value =
 
 
 {-| Defines a default value which will be displayed in a `button`, `option`,
-`input`, `li`, `meter`, `progress`, or `param`.
+`input`, `li`, `meter`, `progress`, `param`, or `textarea`.
 -}
 value : String -> Attribute
 value value =


### PR DESCRIPTION
I was mislead by the docs for the `Html.Attributes.value` function, since it didn't mention that it worked with `textarea`. I was instead trying to bind the contents of the `textarea` to the underlying model by setting the value of an inner text node.

Thanks for elm! It's been really great so far!