### PR TITLE
Update example of targetChecked

### DIFF
--- a/src/Html/Events.elm
+++ b/src/Html/Events.elm
@@ -105,9 +105,9 @@ targetValue =
 {-| A `Json.Decoder` for grabbing `event.target.checked` from the triggered
 event. This is useful for input event on checkboxes.
 
-    onInput : Signal.Address a -> (Bool -> a) -> Attribute
-    onInput address contentToValue =
-        on "input" targetChecked (\bool -> Signal.message address (contentToValue bool))
+    onChange : Signal.Address a -> (Bool -> a) -> Attribute
+    onChange address contentToValue =
+        on "change" targetChecked (\bool -> Signal.message address (contentToValue bool))
 -}
 targetChecked : Json.Decoder Bool
 targetChecked =


### PR DESCRIPTION
I think it is better to use 'change' instead of 'input' because 'input' never fires for checkbox.

Tested in:
Chrome 49.0.2623.87 (64-bit)
Safari 9.0.3 (11601.4.4)
Firefox 44.0.2

Test Code:
```
<input type="checkbox" id="t"/>
```
```
document.getElementById('t').addEventListener('input', function () {
	alert('input')
})
```